### PR TITLE
Better YAML

### DIFF
--- a/src/MarkdownFile.py
+++ b/src/MarkdownFile.py
@@ -29,8 +29,6 @@ class MarkdownFile:
         """
         # this block needs to be set by each method that wants to retrieve YAML
         # values; when instantiating in YamlParser I had circular dependencys
-        #value = None
-        values = set()
         file = MarkdownFile
         file = self._openFile()
         self.fStream = file.read()
@@ -41,11 +39,15 @@ class MarkdownFile:
         # file in the Parser class (example in .searchFilesWithTag())
         # the key has to be given as first argument in a string without the colon
         findYAMLTags = YamlParser("tags", self.fStream)
-        # execute function to find tag in YamlParser
+        # execute method to find tag in YamlParser; in the called method another
+        # method is called to find the specific tags
+        # returns None if no YAML is found in a file
         values = findYAMLTags._findAllYAML()
+        # if this is the case, then values is made a set so that the simple tags
+        # can be added to it, because one can't add to NoneType
         if values == None:
             values = set()
-        #print(values)
+
 
         # find simple tags
         simpleTags = re.compile(r"((?<=#)\S+)") # Find all tags in file with format #tag1 #tag2 ...
@@ -56,7 +58,6 @@ class MarkdownFile:
 
         # a set of all values (here: tags) is returned; a method in
         # Parser.py then checks if the entered tag is part of it
-        #print(values)
         return values
 
 

--- a/src/MarkdownFile.py
+++ b/src/MarkdownFile.py
@@ -42,7 +42,8 @@ class MarkdownFile:
         # the key has to be given as first argument in a string without the colon
         findYAMLTags = YamlParser("tags", self.fStream)
         # execute function to find tag in YamlParser
-        values = findYAMLTags._findValueInYAML()
+        values = findYAMLTags._findAllYAML()
+        print(values)
 
         # find simple tags
         simpleTags = re.compile(r"((?<=#)\S+)") # Find all tags in file with format #tag1 #tag2 ...
@@ -53,6 +54,7 @@ class MarkdownFile:
 
         # a set of all values (here: tags) is returned; a method in
         # Parser.py then checks if the entered tag is part of it
+        print(values)
         return values
 
 

--- a/src/MarkdownFile.py
+++ b/src/MarkdownFile.py
@@ -29,7 +29,7 @@ class MarkdownFile:
         """
         # this block needs to be set by each method that wants to retrieve YAML
         # values; when instantiating in YamlParser I had circular dependencys
-        value = None
+        #value = None
         values = set()
         file = MarkdownFile
         file = self._openFile()
@@ -43,7 +43,9 @@ class MarkdownFile:
         findYAMLTags = YamlParser("tags", self.fStream)
         # execute function to find tag in YamlParser
         values = findYAMLTags._findAllYAML()
-        print(values)
+        if values == None:
+            values = set()
+        #print(values)
 
         # find simple tags
         simpleTags = re.compile(r"((?<=#)\S+)") # Find all tags in file with format #tag1 #tag2 ...
@@ -54,7 +56,7 @@ class MarkdownFile:
 
         # a set of all values (here: tags) is returned; a method in
         # Parser.py then checks if the entered tag is part of it
-        print(values)
+        #print(values)
         return values
 
 

--- a/src/yamlParser.py
+++ b/src/yamlParser.py
@@ -8,11 +8,11 @@ class YamlParser:
         self.result = None
         
     def _findAllYAML(self):
+        # matches everything inside the frontmatter YAML (at least the first
+        # occurence of --- this is matched ---)
         match = re.search(self._regexAllYAML, self.fStream)
-        #print(match)
         if match != None:
             self.result = match.group()
-            #print(self.result)
             return self._findValueInYAML()
         else:
             return None
@@ -35,41 +35,31 @@ class YamlParser:
         # all the values are stored in this set
         self.values = set()
 
-
+        # matches the entry associated with the given key in the YAML from ._findAllYAML
         match = re.search(self._regexFindKey, self.result)
         result1 = None
         result2 = None
 
         if match != None:
             result1 = match.group(1)
-            #print(result1)
             result2 = match.group(2)
-            #print(result2)
 
-        # code works as expected until here
 
         if result1 != None: # Find all values in YAML with format key: [value1, value2,...]
             new_result1 = result1.split(',')
-            #print(new_result1)
             for element in new_result1:
                 element = element.strip('\"')
                 element = element.strip()
-                #print(element)
                 self.values.add(element)
-            #print(self.values)
         # Find all values in YAML with format
         # key:
         # - value1
         # - value2
         # ...
         elif result2 != None:
-            #print(result2)
             result2 = result2.split()
-            #print(result2)
             for element in result2:
                 if element != '-':
                     element = element.strip('\"')
                     self.values.add(element)
-            #print(self.values)
-        #print(self.values)
         return self.values

--- a/src/yamlParser.py
+++ b/src/yamlParser.py
@@ -12,11 +12,11 @@ class YamlParser:
         #print(match)
         if match != None:
             self.result = match.group()
-            print(self.result)
             #print(self.result)
-            self._findValueInYAML()
+            return self._findValueInYAML()
         else:
-            return set()
+            return None
+
 
     def _findValueInYAML(self) -> set:
         """Return a set of all values stored in YAML
@@ -70,6 +70,6 @@ class YamlParser:
                 if element != '-':
                     element = element.strip('\"')
                     self.values.add(element)
-            print(self.values)
+            #print(self.values)
         #print(self.values)
         return self.values

--- a/src/yamlParser.py
+++ b/src/yamlParser.py
@@ -2,9 +2,22 @@ import re
 
 class YamlParser:
     def __init__(self, key, fStream):
-        self._regexFindYAML = rf'(?:(?<={key}:\s\[)(.+?)(?=\]))|(?:(?<={key}:\n)((?:-\s\S*\n?)+))'
+        self._regexAllYAML = r'(?<=---\n)(?:.*\n)+(?=---)'
+        self._regexFindKey = rf'(?:(?<={key}:).*?\[(.+?)(?=\]))|(?:(?<={key}:).*\n((?:-\s.*\n?)+))'
         self.fStream = fStream
+        self.result = None
         
+    def _findAllYAML(self):
+        match = re.search(self._regexAllYAML, self.fStream)
+        #print(match)
+        if match != None:
+            self.result = match.group()
+            print(self.result)
+            #print(self.result)
+            self._findValueInYAML()
+        else:
+            return set()
+
     def _findValueInYAML(self) -> set:
         """Return a set of all values stored in YAML
 
@@ -23,29 +36,40 @@ class YamlParser:
         self.values = set()
 
 
-        match = re.search(self._regexFindYAML, self.fStream)
+        match = re.search(self._regexFindKey, self.result)
         result1 = None
         result2 = None
 
         if match != None:
             result1 = match.group(1)
+            #print(result1)
             result2 = match.group(2)
+            #print(result2)
+
+        # code works as expected until here
 
         if result1 != None: # Find all values in YAML with format key: [value1, value2,...]
             new_result1 = result1.split(',')
+            #print(new_result1)
             for element in new_result1:
-                self.values.add(element.strip())
-
+                element = element.strip('\"')
+                element = element.strip()
+                #print(element)
+                self.values.add(element)
+            #print(self.values)
         # Find all values in YAML with format
         # key:
         # - value1
         # - value2
         # ...
         elif result2 != None:
-            result2 = result2.strip('\n')
+            #print(result2)
             result2 = result2.split()
+            #print(result2)
             for element in result2:
                 if element != '-':
+                    element = element.strip('\"')
                     self.values.add(element)
-
+            print(self.values)
+        #print(self.values)
         return self.values


### PR DESCRIPTION
It now finds YAML like this as well.
It also strips the values of `""`.

![grafik](https://user-images.githubusercontent.com/72164229/107421588-6f909480-6b1a-11eb-8a25-4e914b3d8391.png)

Everything as highlighted above is acceptable YAML syntax. Blank lines between list values are not allowed (see above), and there must be a whitespace after the `-` in list syntax (which would otherwise also be invalid in Obsidian).

Only the first occurrence of 
```
---
here is the yaml
---
```
is checked.

Pytest threw no errors, my tests with my own test vault worked.