### PR TITLE
updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ print(yamlIterator.findAllYAML(YAML_METHOD.ITERATE))
   pairs in YAML as a dictionary with the key as a string and its associated
   values as a set
 
+Currently, the YAML parser is limited [(see the comments for details)](https://github.com/danymat/Obsidian-Markdown-Parser/blob/main/src/YamlParser.py).
+
 ### MarkdownFile
 
 #### Attributes
@@ -104,7 +106,7 @@ filesWithSpecificTag = parser.searchFilesWithTag('tag1')
 
 ## Roadmap
 
-New features I intent to add:
+New features I intend to add:
 
 - [ ] Add more tests
 - [X] Ignore .obsidian/ folder
@@ -118,5 +120,3 @@ this repository, and create a pull request from it. Below is the list of all con
 Contributors:
 
 - Daniel Mathiot ([danymat](https://github.com/danymat))
-- Christian Körtner ([archelpeg](https://github.com/archelpeg))
-


### PR DESCRIPTION
I updated the Readme, so that users know that the YAML parser is limited (and can check the comments in the code to see what it supports).

I think that using a library for it makes more sense. I've thought about that before, but now I've noticed that the YAML frontmatter is often used very differently compared to the Obsidian docs (including nested YAML), for which my implementation was not designed. I think I'd need to do a complete rewrite of the YAML parser to account for these things, which I wouldn't have a personal use for. Therefore, I think it would be better to use a library for it in the future.